### PR TITLE
Fix Remove-CCMCacheElement Variable OlderThan to be UTC

### DIFF
--- a/Powershell/Clean-CMClientCache/Clean-CMClientCache.ps1
+++ b/Powershell/Clean-CMClientCache/Clean-CMClientCache.ps1
@@ -1082,7 +1082,7 @@ Function Remove-CCMCacheElement {
         [psobject]$RemovedCache = @()
 
         ## Set the date threshold
-        [datetime]$OlderThan = (Get-Date).AddDays( - $ReferencedThreshold)
+        [datetime]$OlderThan = (Get-Date).ToUniversalTime().AddDays( - $ReferencedThreshold)
     }
     Process {
         Try {


### PR DESCRIPTION
According to the MS documentation I could find the cache item Last Reference Time is stored in UTC time.  I've added a fix to convert the local time to UTC when setting the $OlderThan variable.

https://docs.microsoft.com/en-us/sccm/core/support/clispy (2/3 of the way down under "Cache Items")

#7 