### PR TITLE
Update README.md

### DIFF
--- a/Compliance/DNS Server Vulnerability (CVE-2020-1350)/README.md
+++ b/Compliance/DNS Server Vulnerability (CVE-2020-1350)/README.md
@@ -1,7 +1,6 @@
 ## DNS Server Vulnerability (CVE-2020-1350) Workaround
 
 Implements the workaround for the CVE-2020-1350 wormable exploit.
-A POC is already available on github: https://github.com/ZephrFish/CVE-2020-1350/blob/master/exploit.sh
 
 ## Tree
 


### PR DESCRIPTION
Remove ZephrFish POC reference as it is not a real POC -- https://blog.zsec.uk/cve-2020-1350-research/

There are DoS POCs available such as https://github.com/maxpl0it/CVE-2020-1350-DoS which could be referenced instead if preffered.